### PR TITLE
doc(ubuntu): add ubuntu 24.11 instructions

### DIFF
--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -14,7 +14,7 @@ is running by default.
 ## Generate strong key on your laptop or workstation/desktop
 ## If you already have keys DO NOT overwrite your previous keys
 
-ssh-keygen
+ssh-keygen -t ed25519 -a 32 -f ~/.ssh/$localhost-to-$remotehost
 
 ## Optionally set a passphrase
 
@@ -27,21 +27,13 @@ ssh-copy-id username@remote_host
 We don't want to allow anyone to login as root remotely ever. You must be a
 `sudoer` with public key auth to elevate to root.
 
-SSH into your server and run `sudoedit /etc/ssh/sshd_config`
-
-See
-[stackoverflow question](https://superuser.com/questions/785187/sudoedit-why-use-it-over-sudo-vi)
-for reasons to use sudoedit over sudo.
+SSH into your server and run
 
 ```bash
-## Uncomment PasswordAuthentication and set value to no
-PasswordAuthentication no
-
-## Disable root login
-PermitRootLogin no
-
-## Optionally disable X11 forwarding
-X11Forwarding no
+printf '%s\n' 'PermitRootLogin no' | sudo tee /etc/ssh/sshd_config.d/01-root.conf
+printf '%s\n' \
+    'PubkeyAuthentication yes' \
+    'PasswordAuthentication no' | sudo tee /etc/ssh/sshd_config.d/01-pubkey.conf
 ```
 
 Save file and then run `systemctl restart ssh` Before closing your session, open

--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -76,11 +76,9 @@ systemctl enable --now podman
 > This is only necessary if you are setting up the reverse proxy (or any service
 > on ports <1024).
 
-`sudoedit /etc/sysctl.conf`
-
 ```bash
-## Add the following line and save
-net.ipv4.ip_unprivileged_port_start=80
+printf '%s\n' 'net.ipv4.ip_unprivileged_port_start=80' | sudo tee /etc/sysctl.d/99-unprivileged-port-binding.conf
+sysctl -w 'net.ipv4.ip_unprivileged_port_start=80'
 ```
 
 ### Option 2: Redirect using firewalls

--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -70,7 +70,7 @@ systemctl enable --now podman
 
 ## Allow rootless binding port 80+
 
-### Option 1: Modify range of unprivileged ports
+### Modify range of unprivileged ports
 
 > [!NOTE]
 > This is only necessary if you are setting up the reverse proxy (or any service
@@ -80,16 +80,6 @@ systemctl enable --now podman
 printf '%s\n' 'net.ipv4.ip_unprivileged_port_start=80' | sudo tee /etc/sysctl.d/99-unprivileged-port-binding.conf
 sysctl -w 'net.ipv4.ip_unprivileged_port_start=80'
 ```
-
-### Option 2: Redirect using firewalls
-
-See
-[jdboyd blog post for PARTIAL examples using UFW, iptables, and nftables](https://blog.jdboyd.net/2024/05/exposing-privileged-ports-with-podman/)
-
-> [!WARNING]
-> IF UTILIZING THIS METHOD
->
-> CREATE RULES TO ALLOW SSH BEFORE ENABLING THE FIREWALL
 
 ## Prepare container user
 

--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -117,17 +117,18 @@ loginctl enable-linger $ctuser
 ## Setup $ctuser env
 
 > [!NOTE]
-> See the following for reasons to use machinectl instead of su
-> [RedHat blog post](https://www.redhat.com/en/blog/sudo-rootless-podman)
->
-> [reddit post](https://old.reddit.com/r/linuxadmin/comments/rxrczr/in_interesting_tidbit_i_just_learned_about_the/)
+> Use machinectl instead of sudo or su to get a shell that is fully isolated
+> from the original session. See the developers comments on the problem
+> [with su](https://github.com/systemd/systemd/issues/825#issuecomment-127917622)
+> as well as the purpose of
+> [machinectl shell](https://github.com/systemd/systemd/pull/1022#issuecomment-136133244)
 
 ```bash
 # Switch to $ctuser
 # Note do not remove the trailing @
 machinectl shell $ctuser@ /bin/bash
 # Create dirs
-mkdir -p ~/.config/{containers/systemd,environment.d} ~/containers/storage
+mkdir -p ~/.config/{containers/systemd,environment.d}
 # Prepare `systemd --user` env
 echo 'XDG_RUNTIME_DIR=/run/user/2000' >> ~/.config/environment.d/10-xdg.conf
 # Enable container auto-update

--- a/Ubuntu.md
+++ b/Ubuntu.md
@@ -1,6 +1,6 @@
 # Ubuntu Server
 
-Setting up rootless podman on a fresh ubuntu 24.10 server.
+Setting up rootless podman on a fresh Ubuntu 24.10 server.
 
 > [!WARNING]
 > Perform `sudo apt update && sudo apt upgrade` immediately. Reboot system.

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -1,0 +1,157 @@
+# Ubuntu Server 
+
+Setting up rootless podman on a fresh ubuntu 24.10 server.
+
+> [!WARNING]
+> Perform `sudo apt update && sudo apt upgrade` immediately. Perform reboot if necessary
+
+## SSH
+
+SSH is optional, but highly encouraged. OpenSSH is installed by default and sshd is running by default.
+
+```bash
+## Generate strong key on your laptop or workstation/desktop
+## If you already have keys DO NOT overwrite your previous keys
+
+ssh-keygen
+
+## Optionally set a passphrase
+
+## Copy key to Ubuntu
+ssh-copy-id username@remote_host
+```
+
+## Override `sshd` config
+
+We don't want to allow anyone to login as root remotely ever. You must be a
+`sudoer` with public key auth to elevate to root.
+
+SSH into your server and run `sudoedit /etc/ssh/sshd_config` See [stackoverflow question](https://superuser.com/questions/785187/sudoedit-why-use-it-over-sudo-vi) for reasons to use sudoedit over sudo.
+
+```bash
+## Uncomment PasswordAuthentication and set value to no
+PasswordAuthentication no
+
+## Disable root login
+PermitRootLogin no
+
+## Optionally disable X11 forwarding
+X11Forwarding no
+```
+Save file and then run `systemctl restart ssh` Before closing your session, open a new terminal and test SSH is functioning correctly.
+
+## Podman
+
+Podman is a daemonless container hypervisor. This document prepares a fully
+rootless environment for our containers to run in.
+
+## Install
+
+```bash
+dnf install podman
+systemctl enable --now podman
+```
+
+> [!NOTE]
+> Read the docs.
+> `man podman-systemd.unit`
+
+## Prepare host networking stack
+
+## slirp4netns
+
+> [!NOTE]
+> This may not be necessary but my system is currently using it.
+
+```bash
+dnf install slirp4netns
+```
+
+## Install DNS server for `podman`
+
+> [!NOTE]
+> Not sure how to resolve these correctly yet but the journal logs it
+> so it's running for something.
+
+```bash
+dnf install aardvark-dns
+```
+
+## Allow rootless binding port 80+
+
+> [!NOTE]
+> This is only necessary if you are setting up the reverse proxy.
+
+```bash
+printf '%s\n' 'net.ipv4.ip_unprivileged_port_start=80' > /etc/sysctl.d/99-unprivileged-port-binding.conf
+sysctl 'net.ipv4.ip_unprivileged_port_start=80'
+```
+
+## Allow containers to route within multiple networks
+
+```bash
+printf '%s\n' 'net.ipv4.conf.all.rp_filter=2' > /etc/sysctl.d/99-reverse-path-loose.conf
+sysctl -w net.ipv4.conf.all.rp_filter=2
+```
+
+## Prepare container user
+
+This user will be the owner of all containers with no login shell or root
+privileges.
+
+```bash
+# Prepare a group id outside of the normal range
+groupadd --gid 2000 $ctuser
+# Create user with restrictions
+# We need the $HOME to live in
+useradd --create-home \
+    --shell /usr/bin/false \
+    --password $ctuser_pw \
+    --no-user-group \
+    --gid $ctuser \
+    --groups systemd-journal \
+    --uid 2000 \
+    $ctuser
+# Lock user from password login
+usermod --lock $ctuser
+# Add container sub-ids
+usermod --add-subuids 200000-299999 --add-subgids 200000-299999 $ctuser
+# Start $ctuser session at boot without login
+loginctl enable-linger $ctuser
+```
+
+> [!TIP]
+> Optionally setup ssh keys to directly login to $ctuser.
+
+> [!NOTE]
+> The login shell doesn't exist. Launch `bash -l` manually to get a shell or
+> else your `ssh` will exit with a status of 1.
+
+## Setup $ctuser env
+
+```bash
+# Switch to user (`-i` doesn't work without a login shell)
+sudo -u $ctuser bash -l
+# Create dirs
+mkdir -p ~/.config/{containers/systemd,environment.d} ~/containers/storage
+# Prepare `systemd --user` env
+echo 'XDG_RUNTIME_DIR=/run/user/2000' >> ~/.config/environment.d/10-xdg.conf
+# Enable container auto-update
+podman system migrate
+# WARNING: Set strict versions for all containers or risk catastrophe
+systemctl --user enable --now podman-auto-update
+exit
+```
+
+> [!WARNING]
+> I disabled SELinux to not deal with this for every container.
+> /etc/selinux/config -> `SELINUX=disabled`
+
+> [!NOTE]
+> Set up the correct policies permanently instead of disabling SELinux
+
+Temporarily set SELinux policy to allow containers to use devices.
+
+```bash
+setsebool -P container_use_devices 1
+```

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -50,7 +50,7 @@ rootless environment for our containers to run in.
 ## Install
 
 ```bash
-sudo apt install podman
+sudo apt install podman systemd-container
 
 ## Make sure podman is running
 systemctl enable --now podman
@@ -95,7 +95,9 @@ See [jdboyd blog post for PARTIAL examples using UFW, iptables, and nftables](ht
 ## Prepare container user
 
 This user will be the owner of all containers with no login shell or root
-privileges. 
+privileges.
+
+Container user should have range of uid/gid automatically generated. See [subuid and subgid tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration) to verify range or create if it does not exist.
 
 Note $ctuser is a placeholder, replace with your username
 
@@ -114,8 +116,6 @@ sudo useradd --create-home \
     $ctuser
 # Lock user from password login
 sudo usermod --lock $ctuser
-# Add container sub-ids
-sudo usermod --add-subuids 200000-299999 --add-subgids 200000-299999 $ctuser
 # Start $ctuser session at boot without login
 loginctl enable-linger $ctuser
 ```
@@ -127,9 +127,6 @@ loginctl enable-linger $ctuser
 > [RedHat blog post](https://www.redhat.com/en/blog/sudo-rootless-podman)
 >
 > [reddit post](https://old.reddit.com/r/linuxadmin/comments/rxrczr/in_interesting_tidbit_i_just_learned_about_the/)
-
-Install systemd-container
-`sudo apt install systemd-container`
 
 ```bash
 # Switch to $ctuser

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -128,9 +128,13 @@ loginctl enable-linger $ctuser
 >
 > [reddit post](https://old.reddit.com/r/linuxadmin/comments/rxrczr/in_interesting_tidbit_i_just_learned_about_the/)
 
+Install systemd-container
+`sudo apt install systemd-container`
+
 ```bash
 # Switch to $ctuser
-machinectl shell $ctuser
+# Note do not remove the trailing @
+machinectl shell $ctuser@ /bin/bash
 # Create dirs
 mkdir -p ~/.config/{containers/systemd,environment.d} ~/containers/storage
 # Prepare `systemd --user` env

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -68,10 +68,8 @@ systemctl enable --now podman
 > As of Podman 5.0 Pasta is the default rootless networking tool.
 > 
 > Podman 5.0 is available in standard Ubuntu repo since 24.10.
-
-```bash
-sudo apt install passt
-```
+>
+> Both are installed with podman see [rootless networking for configuration](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#networking-configuration)
 
 ## Allow rootless binding port 80+
 
@@ -142,17 +140,4 @@ podman system migrate
 # WARNING: Set strict versions for all containers or risk catastrophe
 systemctl --user enable --now podman-auto-update
 exit
-```
-
-> [!WARNING]
-> I disabled SELinux to not deal with this for every container.
-> /etc/selinux/config -> `SELINUX=disabled`
-
-> [!NOTE]
-> Set up the correct policies permanently instead of disabling SELinux
-
-Temporarily set SELinux policy to allow containers to use devices.
-
-```bash
-setsebool -P container_use_devices 1
 ```

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -101,10 +101,10 @@ Note $ctuser is a placeholder, replace with your username
 
 ```bash
 # Prepare a group id outside of the normal range
-groupadd --gid 2000 $ctuser
+sudo groupadd --gid 2000 $ctuser
 # Create user with restrictions
 # We need the $HOME to live in
-useradd --create-home \
+sudo useradd --create-home \
     --shell /usr/bin/false \
     --password $ctuser_pw \
     --no-user-group \
@@ -113,9 +113,9 @@ useradd --create-home \
     --uid 2000 \
     $ctuser
 # Lock user from password login
-usermod --lock $ctuser
+sudo usermod --lock $ctuser
 # Add container sub-ids
-usermod --add-subuids 200000-299999 --add-subgids 200000-299999 $ctuser
+sudo usermod --add-subuids 200000-299999 --add-subgids 200000-299999 $ctuser
 # Start $ctuser session at boot without login
 loginctl enable-linger $ctuser
 ```

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -1,4 +1,4 @@
-# Ubuntu Server 
+# Ubuntu Server
 
 Setting up rootless podman on a fresh ubuntu 24.10 server.
 
@@ -7,7 +7,8 @@ Setting up rootless podman on a fresh ubuntu 24.10 server.
 
 ## SSH
 
-SSH is optional, but highly encouraged. OpenSSH is installed by default and sshd is running by default.
+SSH is optional, but highly encouraged. OpenSSH is installed by default and sshd
+is running by default.
 
 ```bash
 ## Generate strong key on your laptop or workstation/desktop
@@ -26,9 +27,11 @@ ssh-copy-id username@remote_host
 We don't want to allow anyone to login as root remotely ever. You must be a
 `sudoer` with public key auth to elevate to root.
 
-SSH into your server and run `sudoedit /etc/ssh/sshd_config` 
+SSH into your server and run `sudoedit /etc/ssh/sshd_config`
 
-See [stackoverflow question](https://superuser.com/questions/785187/sudoedit-why-use-it-over-sudo-vi) for reasons to use sudoedit over sudo.
+See
+[stackoverflow question](https://superuser.com/questions/785187/sudoedit-why-use-it-over-sudo-vi)
+for reasons to use sudoedit over sudo.
 
 ```bash
 ## Uncomment PasswordAuthentication and set value to no
@@ -40,7 +43,9 @@ PermitRootLogin no
 ## Optionally disable X11 forwarding
 X11Forwarding no
 ```
-Save file and then run `systemctl restart ssh` Before closing your session, open a new terminal and test SSH is functioning correctly.
+
+Save file and then run `systemctl restart ssh` Before closing your session, open
+a new terminal and test SSH is functioning correctly.
 
 ## Podman
 
@@ -57,8 +62,7 @@ systemctl enable --now podman
 ```
 
 > [!NOTE]
-> Read the docs.
-> `man podman-systemd.unit`
+> Read the docs. `man podman-systemd.unit`
 
 ## Prepare host networking stack
 
@@ -66,28 +70,33 @@ systemctl enable --now podman
 
 > [!NOTE]
 > As of Podman 5.0 Pasta is the default rootless networking tool.
-> 
+>
 > Podman 5.0 is available in standard Ubuntu repo since 24.10.
 >
-> Both are installed with podman see [rootless networking for configuration](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#networking-configuration)
+> Both are installed with podman see
+> [rootless networking for configuration](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#networking-configuration)
 
 ## Allow rootless binding port 80+
 
-### Option 1: Modify range of unpriveleged ports
+### Option 1: Modify range of unprivileged ports
 
 > [!NOTE]
-> This is only necessary if you are setting up the reverse proxy (or any service on ports <1024).
+> This is only necessary if you are setting up the reverse proxy (or any service
+> on ports <1024).
 
 `sudoedit /etc/sysctl.conf`
+
 ```bash
 ## Add the following line and save
 net.ipv4.ip_unprivileged_port_start=80
 ```
 
 ### Option 2: Redirect using firewalls
-See [jdboyd blog post for PARTIAL examples using UFW, iptables, and nftables](https://blog.jdboyd.net/2024/05/exposing-privileged-ports-with-podman/)
 
->[!WARNING]
+See
+[jdboyd blog post for PARTIAL examples using UFW, iptables, and nftables](https://blog.jdboyd.net/2024/05/exposing-privileged-ports-with-podman/)
+
+> [!WARNING]
 > IF UTILIZING THIS METHOD
 >
 > CREATE RULES TO ALLOW SSH BEFORE ENABLING THE FIREWALL
@@ -97,7 +106,9 @@ See [jdboyd blog post for PARTIAL examples using UFW, iptables, and nftables](ht
 This user will be the owner of all containers with no login shell or root
 privileges.
 
-Container user should have range of uid/gid automatically generated. See [subuid and subgid tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration) to verify range or create if it does not exist.
+Container user should have range of uid/gid automatically generated. See
+[subuid and subgid tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration)
+to verify range or create if it does not exist.
 
 Note $ctuser is a placeholder, replace with your username
 
@@ -119,12 +130,13 @@ sudo usermod --lock $ctuser
 # Start $ctuser session at boot without login
 loginctl enable-linger $ctuser
 ```
->[!NOTE]
+
+> [!NOTE]
 > Consider removing bash history entry that contains the password entered above
 
 ## Setup $ctuser env
 
->[!NOTE]
+> [!NOTE]
 > See the following for reasons to use machinectl instead of su
 > [RedHat blog post](https://www.redhat.com/en/blog/sudo-rootless-podman)
 >

--- a/ubuntu.md
+++ b/ubuntu.md
@@ -119,6 +119,8 @@ sudo usermod --lock $ctuser
 # Start $ctuser session at boot without login
 loginctl enable-linger $ctuser
 ```
+>[!NOTE]
+> Consider removing bash history entry that contains the password entered above
 
 ## Setup $ctuser env
 


### PR DESCRIPTION
This adds an ubuntu.md setup for users using ubuntu server. I used your AlmaLinux setup as a template and modified it (for my uses). 
There are some removals and some additions based on ubuntu defaults. I also changed some commands based on my research (sudoedit instead of sudo and machinectl instead of sudo -u). 